### PR TITLE
Enhance interface layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,51 +1,57 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>wfc</title>
 </head>
-
 <body>
-    <div id="topContainer">
-        <canvas id="islandCanvas" width="600" height="600"></canvas>
-        <canvas id="elevationCanvas" width="600" height="600"></canvas>
+    <header>
+        <h1>Island Generator</h1>
+    </header>
 
+    <div id="app">
+        <div id="canvasContainer">
+            <canvas id="islandCanvas" width="600" height="600"></canvas>
+            <canvas id="elevationCanvas" class="hidden" width="600" height="600"></canvas>
+        </div>
+
+        <div id="controls">
+            <div class="control-group">
+                <label for="treeDensitySlider">Tree Density</label>
+                <input type="range" id="treeDensitySlider" min="0" max="100" value="50">
+            </div>
+
+            <div class="control-group">
+                <label for="islandSize">Island Size</label>
+                <input type="range" id="islandSize" min="1" max="10" value="4">
+            </div>
+
+            <div class="control-group">
+                <label for="cloudOpacitySlider">Cloud Opacity</label>
+                <input type="range" id="cloudOpacitySlider" min="0" max="1" step="0.05" value="0.5">
+            </div>
+
+            <div class="control-group">
+                <button id="toggleWavesButton" onclick="toggleWaves()">Toggle Waves</button>
+                <button id="mergeToggleButton" onclick="toggleMerge()">Toggle Elevation Merge</button>
+            </div>
+
+            <button id="debugModeButton">Debug Mode</button>
+
+            <fieldset id="debugControls" class="hidden">
+                <legend>Debug Display</legend>
+                <label><input type="radio" name="displayMode" value="elevation" checked> Elevation</label>
+                <label><input type="radio" name="displayMode" value="waves"> Waves</label>
+                <label><input type="radio" name="displayMode" value="clouds"> Clouds</label>
+            </fieldset>
+
+            <button id="recreateMapButton">Recreate Map</button>
+        </div>
     </div>
-    <!-- <canvas id="waterAnimationCanvas" width="600" height="600" style="display: hidden;"></canvas> -->
-    <br>
-    <!-- <button id="toggleGridButton">Toggle Grid</button> -->
-    <div>
-        <label for="treeDensitySlider">Tree Density:</label>
-        <input type="range" id="treeDensitySlider" min="0" max="100" value="50">
-
-        <label for="islandSize">Island Size:</label>
-        <input type="range" id="islandSize" min="1" max="10" value="4">
-
-        <label for="cloudOpacitySlider">Cloud Opacity</label>
-        <input type="range" id="cloudOpacitySlider" min="0" max="1" step="0.05" value="0.5">
-
-
-        <button id="toggleWavesButton" onclick="toggleWaves()">Toggle Waves</button>
-        <button id="mergeToggleButton" onclick="toggleMerge()">Toggle Elevation Merge</button>
-
-    </div>
-
-    <div>
-        <label><input type="radio" name="displayMode" value="elevation" checked> Elevation</label>
-        <label><input type="radio" name="displayMode" value="waves"> Waves</label>
-        <label><input type="radio" name="displayMode" value="clouds"> Clouds</label>
-    </div>
-    
-
-
-
-    <button id="recreateMapButton">Recreate Map</button>
 
     <script src="perlin.js"></script>
     <script src="script.js"></script>
 </body>
-
 </html>

--- a/script.js
+++ b/script.js
@@ -34,6 +34,8 @@ const elevationCtx = elevationCanvas.getContext("2d");
 // const waterAnimationCanvas = document.getElementById("waterAnimationCanvas");
 // const waterCtx = waterAnimationCanvas.getContext("2d");
 
+let debugMode = false; // Track whether debug elements are visible
+
 let collapseQueue = []; // Queue to store cells to collapse
 let autoCollapse = false; // Flag for "Skip All" mode
 
@@ -213,6 +215,32 @@ function initializeMap() {
 document
   .getElementById("recreateMapButton")
   .addEventListener("click", initializeMap);
+
+// Toggle visibility of debug elements
+function toggleDebugMode() {
+  debugMode = !debugMode;
+
+  document
+    .getElementById("elevationCanvas")
+    .classList.toggle("hidden", !debugMode);
+  document
+    .getElementById("debugControls")
+    .classList.toggle("hidden", !debugMode);
+
+  const btn = document.getElementById("debugModeButton");
+  btn.textContent = debugMode ? "Hide Debug" : "Debug Mode";
+
+  if (debugMode) {
+    updateDebugDisplay(selectedMode);
+  } else {
+    cancelAnimationFrame(debugAnimationFrameId);
+    elevationCtx.clearRect(0, 0, elevationCanvas.width, elevationCanvas.height);
+  }
+}
+
+document
+  .getElementById("debugModeButton")
+  .addEventListener("click", toggleDebugMode);
 
 // Render the entire grid
 function renderGrid(time = 0) {

--- a/style.css
+++ b/style.css
@@ -1,14 +1,49 @@
-#topContainer {
-    display: flex;           /* Arrange canvases side-by-side */
-    width: 1600px;
-    margin-bottom: 10px;     /* Space between the top and bottom canvases */
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+
+header {
+    background-color: #333;
+    color: #fff;
+    padding: 1rem;
+    text-align: center;
+}
+
+#app {
+    display: flex;
+    gap: 20px;
+    padding: 1rem;
+}
+
+#canvasContainer {
+    display: flex;
+    gap: 10px;
 }
 
 canvas {
-    border: 1px solid black; /* Optional: Border for better visibility */
+    border: 1px solid black;
 }
 
-#waterAnimationCanvas {
-    width: 600px;
-    height: 600px;
+#controls {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    max-width: 300px;
+}
+
+.control-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+fieldset {
+    border: 1px solid #ccc;
+    padding: 10px;
+}
+
+.hidden {
+    display: none;
 }


### PR DESCRIPTION
## Summary
- reorganize HTML with a header, control panel and canvas area
- style page using flexbox for a cleaner interface
- add debug mode toggle to hide debug canvas and controls by default

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861b652354c8330a5b5bb3e259fab2a