### PR TITLE
Refine layout with responsive canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,51 +1,57 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>wfc</title>
 </head>
-
 <body>
-    <div id="topContainer">
-        <canvas id="islandCanvas" width="600" height="600"></canvas>
-        <canvas id="elevationCanvas" width="600" height="600"></canvas>
+    <header>
+        <h1>Island Generator</h1>
+    </header>
 
+    <div id="app">
+        <div id="controls">
+            <div class="control-group">
+                <label for="treeDensitySlider">Tree Density</label>
+                <input type="range" id="treeDensitySlider" min="0" max="100" value="50">
+            </div>
+
+            <div class="control-group">
+                <label for="islandSize">Island Size</label>
+                <input type="range" id="islandSize" min="1" max="10" value="4">
+            </div>
+
+            <div class="control-group">
+                <label for="cloudOpacitySlider">Cloud Opacity</label>
+                <input type="range" id="cloudOpacitySlider" min="0" max="1" step="0.05" value="0.5">
+            </div>
+
+            <div class="control-group">
+                <button id="toggleWavesButton" onclick="toggleWaves()">Toggle Waves</button>
+                <button id="mergeToggleButton" onclick="toggleMerge()">Toggle Elevation Merge</button>
+            </div>
+
+            <button id="debugModeButton">Debug Mode</button>
+
+            <fieldset id="debugControls" class="hidden">
+                <legend>Debug Display</legend>
+                <label><input type="radio" name="displayMode" value="elevation" checked> Elevation</label>
+                <label><input type="radio" name="displayMode" value="waves"> Waves</label>
+                <label><input type="radio" name="displayMode" value="clouds"> Clouds</label>
+            </fieldset>
+
+            <button id="recreateMapButton">Recreate Map</button>
+        </div>
+
+        <div id="canvasContainer">
+            <canvas id="islandCanvas" width="600" height="600"></canvas>
+            <canvas id="elevationCanvas" class="hidden" width="600" height="600"></canvas>
+        </div>
     </div>
-    <!-- <canvas id="waterAnimationCanvas" width="600" height="600" style="display: hidden;"></canvas> -->
-    <br>
-    <!-- <button id="toggleGridButton">Toggle Grid</button> -->
-    <div>
-        <label for="treeDensitySlider">Tree Density:</label>
-        <input type="range" id="treeDensitySlider" min="0" max="100" value="50">
-
-        <label for="islandSize">Island Size:</label>
-        <input type="range" id="islandSize" min="1" max="10" value="4">
-
-        <label for="cloudOpacitySlider">Cloud Opacity</label>
-        <input type="range" id="cloudOpacitySlider" min="0" max="1" step="0.05" value="0.5">
-
-
-        <button id="toggleWavesButton" onclick="toggleWaves()">Toggle Waves</button>
-        <button id="mergeToggleButton" onclick="toggleMerge()">Toggle Elevation Merge</button>
-
-    </div>
-
-    <div>
-        <label><input type="radio" name="displayMode" value="elevation" checked> Elevation</label>
-        <label><input type="radio" name="displayMode" value="waves"> Waves</label>
-        <label><input type="radio" name="displayMode" value="clouds"> Clouds</label>
-    </div>
-    
-
-
-
-    <button id="recreateMapButton">Recreate Map</button>
 
     <script src="perlin.js"></script>
     <script src="script.js"></script>
 </body>
-
 </html>

--- a/script.js
+++ b/script.js
@@ -29,13 +29,30 @@ function initializeGridWithAllOptions() {
 
 const canvas = document.getElementById("islandCanvas");
 const elevationCanvas = document.getElementById("elevationCanvas");
+const canvasContainer = document.getElementById("canvasContainer");
 const ctx = canvas.getContext("2d");
 const elevationCtx = elevationCanvas.getContext("2d");
 // const waterAnimationCanvas = document.getElementById("waterAnimationCanvas");
 // const waterCtx = waterAnimationCanvas.getContext("2d");
 
+let debugMode = false; // Track whether debug elements are visible
+
 let collapseQueue = []; // Queue to store cells to collapse
 let autoCollapse = false; // Flag for "Skip All" mode
+
+function resizeCanvas() {
+  const controls = document.getElementById("controls");
+  const header = document.querySelector("header");
+  const maxWidth = window.innerWidth - controls.offsetWidth - 40;
+  const maxHeight = window.innerHeight - header.offsetHeight - 40;
+  const size = Math.min(maxWidth, maxHeight);
+
+  canvasContainer.style.width = size + "px";
+  canvasContainer.style.height = size + "px";
+}
+
+window.addEventListener("resize", resizeCanvas);
+resizeCanvas();
 
 function applyPreferences() {
     const sliderElement = document.getElementById("islandSize");
@@ -213,6 +230,32 @@ function initializeMap() {
 document
   .getElementById("recreateMapButton")
   .addEventListener("click", initializeMap);
+
+// Toggle visibility of debug elements
+function toggleDebugMode() {
+  debugMode = !debugMode;
+
+  document
+    .getElementById("elevationCanvas")
+    .classList.toggle("hidden", !debugMode);
+  document
+    .getElementById("debugControls")
+    .classList.toggle("hidden", !debugMode);
+
+  const btn = document.getElementById("debugModeButton");
+  btn.textContent = debugMode ? "Hide Debug" : "Debug Mode";
+
+  if (debugMode) {
+    updateDebugDisplay(selectedMode);
+  } else {
+    cancelAnimationFrame(debugAnimationFrameId);
+    elevationCtx.clearRect(0, 0, elevationCanvas.width, elevationCanvas.height);
+  }
+}
+
+document
+  .getElementById("debugModeButton")
+  .addEventListener("click", toggleDebugMode);
 
 // Render the entire grid
 function renderGrid(time = 0) {

--- a/style.css
+++ b/style.css
@@ -1,14 +1,74 @@
-#topContainer {
-    display: flex;           /* Arrange canvases side-by-side */
-    width: 1600px;
-    margin-bottom: 10px;     /* Space between the top and bottom canvases */
+html, body {
+    height: 100%;
+}
+
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+header {
+    background-color: #333;
+    color: #fff;
+    padding: 1rem;
+    text-align: center;
+}
+
+#app {
+    flex: 1;
+    display: flex;
+    padding: 1rem;
+    gap: 20px;
+    align-items: center;
+}
+#controls {
+    width: 250px;
+    max-width: 300px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background-color: #f5f5f5;
+    border-right: 1px solid #ccc;
+    padding: 1rem;
+    height: 100%;
+    box-sizing: border-box;
+}
+
+#canvasContainer {
+    flex: 1;
+    position: relative;
 }
 
 canvas {
-    border: 1px solid black; /* Optional: Border for better visibility */
+    border: 1px solid black;
+    width: 100%;
+    height: 100%;
+    display: block;
 }
 
-#waterAnimationCanvas {
-    width: 600px;
-    height: 600px;
+#elevationCanvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+}
+
+.control-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+fieldset {
+    border: 1px solid #ccc;
+    padding: 10px;
+}
+
+.hidden {
+    display: none;
 }


### PR DESCRIPTION
## Summary
- move controls to a left-side panel and keep canvases in a dedicated container
- style the menu and overlay debug canvas to keep the main view fixed
- add window resize handling so the canvas grows to maximum size without overlapping the menu

## Testing
- `npm test` (fails: Could not read package.json)
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861b652354c8330a5b5bb3e259fab2a