### PR TITLE
Make canvas responsive and center island

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,9 +56,8 @@
 
     <div id="app">
         <div id="canvasContainer">
-            <canvas id="islandCanvas" width="1500" height="1500"></canvas>
-            <canvas id="elevationCanvas" class="hidden" width="600" height="600"></canvas>
-
+            <canvas id="islandCanvas"></canvas>
+            <canvas id="elevationCanvas" class="hidden"></canvas>
         </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -28,11 +28,26 @@ function initializeGridWithAllOptions() {
 }
 
 const canvas = document.getElementById("islandCanvas");
+const canvasContainer = document.getElementById("canvasContainer");
 const elevationCanvas = document.getElementById("elevationCanvas");
 const ctx = canvas.getContext("2d");
 const elevationCtx = elevationCanvas.getContext("2d");
 // const waterAnimationCanvas = document.getElementById("waterAnimationCanvas");
 // const waterCtx = waterAnimationCanvas.getContext("2d");
+
+function resizeCanvas() {
+  canvas.width = canvasContainer.clientWidth;
+  canvas.height = canvasContainer.clientHeight;
+  elevationCanvas.width = canvas.width;
+  elevationCanvas.height = canvas.height;
+}
+
+window.addEventListener("resize", () => {
+  resizeCanvas();
+  renderGrid();
+});
+
+resizeCanvas();
 
 let debugMode = false; // Track whether debug elements are visible
 
@@ -198,6 +213,7 @@ function startCollapse() {
 }
 
 function initializeMap() {
+  resizeCanvas();
   const randomSeed = Math.floor(Math.random() * 10000); // Adjust range if needed
   noise.seed(randomSeed); // Assuming the Perlin noise library has a seed function
 
@@ -246,6 +262,10 @@ document
 function renderGrid(time = 0) {
   ctx.clearRect(0, 0, canvas.width, canvas.height); // Clear previous frame
 
+  const mapPixelSize = gridSize * tileSize;
+  const offsetX = (canvas.width - mapPixelSize) / 2;
+  const offsetY = (canvas.height - mapPixelSize) / 2;
+
   // Draw the land and elevation first
   for (let y = 0; y < gridSize; y++) {
     for (let x = 0; x < gridSize; x++) {
@@ -268,7 +288,7 @@ function renderGrid(time = 0) {
         ctx.fillStyle = baseColor;
       }
 
-      ctx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+      ctx.fillRect(offsetX + x * tileSize, offsetY + y * tileSize, tileSize, tileSize);
     }
   }
 
@@ -315,6 +335,12 @@ function generateMapWithElevation() {
 }
 
 function renderElevationMap() {
+  const mapPixelSize = gridSize * tileSize;
+  const offsetX = (elevationCanvas.width - mapPixelSize) / 2;
+  const offsetY = (elevationCanvas.height - mapPixelSize) / 2;
+
+  elevationCtx.clearRect(0, 0, elevationCanvas.width, elevationCanvas.height);
+
   for (let y = 0; y < gridSize; y++) {
     for (let x = 0; x < gridSize; x++) {
       const cell = grid[y][x];
@@ -329,10 +355,20 @@ function renderElevationMap() {
         const color = `rgb(${grayscaleValue},${grayscaleValue},${grayscaleValue})`;
 
         elevationCtx.fillStyle = color;
-        elevationCtx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+        elevationCtx.fillRect(
+          offsetX + x * tileSize,
+          offsetY + y * tileSize,
+          tileSize,
+          tileSize
+        );
       } else {
         // Clear any previous elevation on water tiles
-        elevationCtx.clearRect(x * tileSize, y * tileSize, tileSize, tileSize);
+        elevationCtx.clearRect(
+          offsetX + x * tileSize,
+          offsetY + y * tileSize,
+          tileSize,
+          tileSize
+        );
       }
     }
   }
@@ -371,6 +407,10 @@ function elevationToColor(elevation) {
 function renderGrid(time = 0) {
   ctx.clearRect(0, 0, canvas.width, canvas.height); // Clear previous frame
 
+  const mapPixelSize = gridSize * tileSize;
+  const offsetX = (canvas.width - mapPixelSize) / 2;
+  const offsetY = (canvas.height - mapPixelSize) / 2;
+
   for (let y = 0; y < gridSize; y++) {
     for (let x = 0; x < gridSize; x++) {
       const cell = grid[y][x];
@@ -392,8 +432,12 @@ function renderGrid(time = 0) {
         ctx.fillStyle = baseColor;
       }
 
-      ctx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+      ctx.fillRect(offsetX + x * tileSize, offsetY + y * tileSize, tileSize, tileSize);
     }
+  }
+
+  if (cloudsEnabled) {
+    renderCloudLayer(time);
   }
 }
 
@@ -538,16 +582,25 @@ document
 
 // Cloud rendering as a separimate layer on top
 function renderCloudLayer(te) {
+  const mapPixelSize = gridSize * tileSize;
+  const offsetX = (canvas.width - mapPixelSize) / 2;
+  const offsetY = (canvas.height - mapPixelSize) / 2;
+
   for (let y = 0; y < gridSize; y++) {
     for (let x = 0; x < gridSize; x++) {
-      const cloudValue = generateCloudNoise(x, y, time);
+      const cloudValue = generateCloudNoise(x, y, te);
 
       // Only render clouds in the highest regions of the noise
       if (cloudValue > 0.7) {
         // Adjust for sparse clouds
         const alpha = cloudOpacity * (cloudValue - 0.7) * 3.3; // Adjust for opacity control
         ctx.fillStyle = `rgba(255, 255, 255, ${Math.min(alpha, 1)})`;
-        ctx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+        ctx.fillRect(
+          offsetX + x * tileSize,
+          offsetY + y * tileSize,
+          tileSize,
+          tileSize
+        );
       }
     }
   }
@@ -626,12 +679,21 @@ function updateDebugDisplay(mode) {
 function animateWaveDebugView(time = 0) {
   elevationCtx.clearRect(0, 0, elevationCanvas.width, elevationCanvas.height);
 
+  const mapPixelSize = gridSize * tileSize;
+  const offsetX = (elevationCanvas.width - mapPixelSize) / 2;
+  const offsetY = (elevationCanvas.height - mapPixelSize) / 2;
+
   for (let y = 0; y < gridSize; y++) {
     for (let x = 0; x < gridSize; x++) {
       const noiseValue = getNoiseValue(x, y, time); // Same noise function as main screen
       const shade = Math.floor(255 * (0.5 + 0.5 * noiseValue)); // Normalize to [0, 255]
       elevationCtx.fillStyle = `rgb(${shade}, ${shade}, 255)`; // Blueish wave effect
-      elevationCtx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+      elevationCtx.fillRect(
+        offsetX + x * tileSize,
+        offsetY + y * tileSize,
+        tileSize,
+        tileSize
+      );
     }
   }
 
@@ -644,12 +706,21 @@ function animateWaveDebugView(time = 0) {
 function animateCloudDebugView(time = 0) {
   elevationCtx.clearRect(0, 0, elevationCanvas.width, elevationCanvas.height);
 
+  const mapPixelSize = gridSize * tileSize;
+  const offsetX = (elevationCanvas.width - mapPixelSize) / 2;
+  const offsetY = (elevationCanvas.height - mapPixelSize) / 2;
+
   for (let y = 0; y < gridSize; y++) {
     for (let x = 0; x < gridSize; x++) {
       const cloudValue = generateCloudNoise(x, y + time); // Same cloud noise function as main screen
       const shade = Math.floor(128 + 127 * cloudValue); // Gray scale from light to dark
       elevationCtx.fillStyle = `rgb(${shade}, ${shade}, ${shade})`; // Shades of gray for clouds
-      elevationCtx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+      elevationCtx.fillRect(
+        offsetX + x * tileSize,
+        offsetY + y * tileSize,
+        tileSize,
+        tileSize
+      );
     }
   }
 
@@ -660,25 +731,43 @@ function animateCloudDebugView(time = 0) {
 
 // Function to render wave debug information on elevationCanvas
 function renderWaveDebugView() {
+  const mapPixelSize = gridSize * tileSize;
+  const offsetX = (elevationCanvas.width - mapPixelSize) / 2;
+  const offsetY = (elevationCanvas.height - mapPixelSize) / 2;
+
   for (let y = 0; y < gridSize; y++) {
     for (let x = 0; x < gridSize; x++) {
       // Get wave noise value for this tile (assuming getNoiseValue is defined)
       const noiseValue = getNoiseValue(x, y, time);
       const shade = Math.floor(255 * (0.5 + 0.5 * noiseValue)); // Normalize to [0, 255]
       elevationCtx.fillStyle = `rgb(${shade}, ${shade}, 255)`; // Blueish shade for waves
-      elevationCtx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+      elevationCtx.fillRect(
+        offsetX + x * tileSize,
+        offsetY + y * tileSize,
+        tileSize,
+        tileSize
+      );
     }
   }
 }
 
 // Function to render cloud debug information on elevationCanvas
 function renderCloudDebugView() {
+  const mapPixelSize = gridSize * tileSize;
+  const offsetX = (elevationCanvas.width - mapPixelSize) / 2;
+  const offsetY = (elevationCanvas.height - mapPixelSize) / 2;
+
   for (let y = 0; y < gridSize; y++) {
     for (let x = 0; x < gridSize; x++) {
       const cloudValue = generateCloudNoise(x, y); // Assuming this function exists
       const shade = Math.floor(255 * cloudValue); // Normalize to [0, 255]
       elevationCtx.fillStyle = `rgba(255, 255, 255, ${cloudValue})`; // White clouds with transparency
-      elevationCtx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+      elevationCtx.fillRect(
+        offsetX + x * tileSize,
+        offsetY + y * tileSize,
+        tileSize,
+        tileSize
+      );
     }
   }
 }

--- a/style.css
+++ b/style.css
@@ -9,6 +9,7 @@ body {
     background: #f8fafc;
     height: 100vh;
     display: flex;
+    overflow: hidden;
 }
 
 .sidebar {
@@ -17,6 +18,7 @@ body {
     border-right: 1px solid #e2e8f0;
     padding: 20px;
     overflow-y: auto;
+    flex-shrink: 0;
 }
 
 .sidebar h2 {
@@ -42,23 +44,28 @@ body {
 }
 
 #app {
+    flex: 1;
     display: flex;
-    gap: 20px;
     padding: 1rem;
 }
 
-.canvas-container {
+#canvasContainer {
     flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     position: relative;
-    overflow: auto;
+    overflow: hidden;
     background: #ffffff;
 }
 
 canvas {
     border: 1px solid black;
-    position: relative;
     background: #ffffff;
     cursor: crosshair;
+    width: 100%;
+    height: 100%;
+    display: block;
 }
 
 #controls {


### PR DESCRIPTION
## Summary
- Adjust layout so the canvas fills remaining space beside the sidebar
- Center island rendering within the dynamically sized canvas
- Align elevation and cloud layers with centered canvas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5a5fc9248330aa15b9aa1e26ac99